### PR TITLE
Minor stuff added

### DIFF
--- a/eclipse-icon-enlarger/pom.xml
+++ b/eclipse-icon-enlarger/pom.xml
@@ -16,6 +16,29 @@
 					<source>1.6</source>
 				</configuration>
 			</plugin>
+			<plugin>
+        		<artifactId>maven-assembly-plugin</artifactId>
+       			 <executions>
+          			<execution>
+            				<phase>package</phase>
+            				<goals>
+              					<goal>single</goal>
+            				</goals>
+          			</execution>
+       			</executions>
+       			<configuration>
+          			<descriptorRefs>
+            			<descriptorRef>jar-with-dependencies</descriptorRef>
+          			</descriptorRefs>
+          			<archive>
+            			<index>true</index>
+            			<manifest>
+              				<addClasspath>true</addClasspath>
+              				<mainClass>testEclipse.FixIcons</mainClass>
+            			</manifest>
+          			</archive>
+       			</configuration>
+        		</plugin>
 		</plugins>
 
 	</build>

--- a/eclipse-icon-enlarger/src/main/java/testEclipse/FixIcons.java
+++ b/eclipse-icon-enlarger/src/main/java/testEclipse/FixIcons.java
@@ -18,6 +18,7 @@ import javax.imageio.ImageIO;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
@@ -39,6 +40,14 @@ public class FixIcons {
 
 	private static final Logger logger = Logger.getLogger(FixIcons.class);
 
+	
+	private static void printHelpAndExit(Options options)
+  {
+    HelpFormatter formatter = new HelpFormatter();
+    formatter.printHelp("FixIcons", options);
+    System.exit(2);
+  }
+	
 	public static final void main(String[] args) {
 		try {
 
@@ -54,6 +63,11 @@ public class FixIcons {
 
 			GnuParser parser = new GnuParser();
 			CommandLine commandLine = parser.parse(options, args);
+			
+			if(!commandLine.hasOption("baseDir") || !commandLine.hasOption("outputDir")) {
+			  printHelpAndExit(options);
+			}
+			
 			String baseDirArg = commandLine.getOptionValue("b");
 			logger.info("Base directory: " + baseDirArg);
 


### PR DESCRIPTION
I made it so that the main program prints a help message instead of a null pointer exception if you run it without arguments.

I also made it so that maven builds an actual distributable jar with a manifest and all those nice things.

So now you can run it with  java -jar target/eclipse-icon-enlarger-0.0.1-SNAPSHOT-jar-with-dependencies.jar

Isn't that absolutely hilarious?? :dancer: 

Someone should probably write some docs. 
